### PR TITLE
Fix end-of-turn token bug

### DIFF
--- a/countdown_task.py
+++ b/countdown_task.py
@@ -88,9 +88,9 @@ def format_reward_function(response: str, end_token: Optional[str] = None) -> fl
     if end_token and response.endswith(end_token):
         response = response[: -len(end_token)]
 
-    think_regex = r"<think>[^<]*<\/think>"
-    answer_regex = r"<answer>[^<]*<\/answer>"
-    full_format_regex = r"^<think>[^<]*<\/think>\n<answer>[^<]*<\/answer>$"
+    think_regex = r"<think>.*?<\/think>"
+    answer_regex = r"<answer>.*?<\/answer>"
+    full_format_regex = r"^<think>.*?<\/think>\n<answer>.*?<\/answer>$"
 
     think_match = re.search(think_regex, response, re.DOTALL)
     answer_match = re.search(answer_regex, response, re.DOTALL)
@@ -116,7 +116,7 @@ def answer_reward_function(
     """
     Checks if the answer uses all numbers exactly once and evaluates to the target
     """
-    answer_regex = r"<answer>([^<]*)</answer>"
+    answer_regex = r"<answer>(.*?)<\/answer>"
     answer_match = re.search(answer_regex, response, re.DOTALL)
     if not answer_match:
         return 0.0

--- a/grpo.py
+++ b/grpo.py
@@ -68,7 +68,9 @@ def rollout(
         next_token = torch.where(is_finished, pad_token_id, next_token)
         tokens[:, cur_pos] = next_token
         if end_token_id is not None:
-            is_finished = is_finished | (next_token == end_token_id)
+            is_end_token = next_token == end_token_id
+            is_generated_token = ~input_text_mask[:, cur_pos]
+            is_finished = is_finished | (is_end_token & is_generated_token)
         prev_pos = cur_pos
         if is_finished.all():
             break

--- a/train.py
+++ b/train.py
@@ -139,6 +139,7 @@ def main(config_path: str):
         success_rate = np.mean(answer_reward)
         format_reward = np.mean(formatted_reward)
         grad_norm = results["grad_norm"]
+        entropy = results["entropy"]
         lr = optimizer.param_groups[0]["lr"]
         loss = results["loss"]
         mean_response_len = np.mean(
@@ -149,7 +150,8 @@ def main(config_path: str):
             f"train success_rate: {success_rate:.2f}, "
             f"grad_norm: {grad_norm:.2f}, duration: {duration:.2f}, "
             f"num_finished_episodes: {num_finished_episodes}, "
-            f"mean_response_len: {mean_response_len:.2f}"
+            f"mean_response_len: {mean_response_len:.2f}, "
+            f"entropy: {entropy:.2f}"
         )
         if step % config["training"]["eval_interval"] == 0:
             eval_success_rate = evaluate(model, tokenizer, device, dtype, config)
@@ -166,6 +168,7 @@ def main(config_path: str):
         tb_writer.add_scalar("num_finished_episodes", num_finished_episodes, step)
         tb_writer.add_scalar("learning_rate", lr, step)
         tb_writer.add_scalar("mean_response_len", mean_response_len, step)
+        tb_writer.add_scalar("entropy", entropy, step)
         for i, episode in enumerate(episodes):
             # Wrap text in <pre> tags to preserve the original text
             # as TensorBoard treats text as markdown.


### PR DESCRIPTION
Hi, not sure how to best inform you, but there's an upstream bug that is likely affecting your efforts to train on the openai/gsm8k dataset.

The issue occurs when an end-of-turn token in the input prompt is mistakenly treated as if the model generated it. You can see the fix here: https://github.com/bodsul/GRPO-Zero/commit/a3a8963888d2e9f2694ff0ceef3b97b9311853b5

Sorry for the inconvenience.